### PR TITLE
fix: search a user token with a refresh token filled

### DIFF
--- a/src/MsGraph.php
+++ b/src/MsGraph.php
@@ -203,7 +203,7 @@ class MsGraph
     public function getTokenData($id = null)
     {
         $id = $this->getUserId($id);
-        return MsGraphToken::where('user_id', $id)->first();
+        return MsGraphToken::where('user_id', $id)->where('refresh_token', '<>', '')->first();
     }
 
     /**


### PR DESCRIPTION
Context:
User token has a refresh token filled in 'ms_graph_tokens' table.
Application token doesn't have refresh token in 'ms_graph_tokens' table.

Probleme: 
if an 'Application token' is created in the 'ms_graph_tokens' table and If the $id in the function getTokenData is egal to 'null' the MsGraphToken model returned is the 'Application token'. This is not correct